### PR TITLE
Feature: google sheets service

### DIFF
--- a/app/src/routes/api/v1/userRouter.js
+++ b/app/src/routes/api/v1/userRouter.js
@@ -114,12 +114,10 @@ class UserRouter {
 
         yield userFind.save();
         this.body = UserSerializer.serialize(userFind);
-        if ( this.request.body.signUpForTesting && this.request.body.signUpForTesting === 'true' ) {
-            try {
-                yield googleSheetsService.updateSheet(userFind);
-            } catch (err) {
-                logger.error(err);
-            }
+        try {
+            yield googleSheetsService.updateSheet(userFind);
+        } catch (err) {
+            logger.error(err);
         }
     }
 

--- a/app/src/routes/api/v1/userRouter.js
+++ b/app/src/routes/api/v1/userRouter.js
@@ -9,6 +9,7 @@ var router = new Router({
     prefix: '/user'
 });
 var StoriesService = require('services/storiesService');
+var googleSheetsService = require('services/googleSheetsService');
 
 
 class UserRouter {
@@ -42,6 +43,13 @@ class UserRouter {
         }
         let userCreate = yield new User(this.request.body).save();
         this.body = UserSerializer.serialize(userCreate);
+        if ( this.request.body.signUpForTesting && this.request.body.signUpForTesting === 'true' ) {
+            try {
+                yield googleSheetsService.updateSheet(this.request.body.email);
+            } catch (err) {
+                logger.error(err);
+            }
+        }
     }
 
      static * createOrGetUser(){
@@ -106,6 +114,13 @@ class UserRouter {
 
         yield userFind.save();
         this.body = UserSerializer.serialize(userFind);
+        if ( this.request.body.signUpForTesting && this.request.body.signUpForTesting === 'true' ) {
+            try {
+                yield googleSheetsService.updateSheet(userFind);
+            } catch (err) {
+                logger.error(err);
+            }
+        }
     }
 
     static * deleteUser(){

--- a/app/src/services/googleSheetsService.js
+++ b/app/src/services/googleSheetsService.js
@@ -1,0 +1,131 @@
+'use strict';
+
+var config = require('config');
+var logger = require('logger');
+var GoogleSpreadsheet = require('google-spreadsheet');
+
+class GoogleSheetsService {
+    constructor(){
+        this.creds = config.get('googleSheets');
+        this.doc = new GoogleSpreadsheet(this.creds.target_sheet_id);
+    }
+
+    * authSheets(creds){
+        return new Promise(function(resolve, reject) {
+            let creds = {
+                private_key : this.creds.private_key.replace(/\\n/g, '\n'),
+                client_email: this.creds.client_email
+            };
+            this.doc.useServiceAccountAuth(creds, function(err, result) {
+              if (err) {
+                return reject(err);
+              }
+              resolve(result);
+            });
+        }.bind(this));
+    }
+
+    * updateSheet(user){
+        try {
+            yield this.authSheets(this.creds);
+            const result = yield this.checkRows();
+            for ( var i = 0; i < result.length; i++ ) {
+              if ( result[i]._value === user.email ) {
+                logger.info('User already exists. Updating....');
+                yield this.updateCells(result[i], user);
+                return;
+              }
+            }
+            return new Promise(function(resolve, reject) {
+                const newRow = {
+                    'agreed_to_test': 'yes',
+                    'Date First Added': this.getDate(),
+                    'Email': user.email,
+                    'First': user.fullName,
+                    'Source': 'My GFW',
+                    'Address Location': user.city + ', ' + user.state + ', ' + user.country,
+                    'Other How do you use or plan to use GFW': user.howDoYouUse,
+                    'Position Primary Responsibilities': user.primaryResponsibilities,
+                    'Organization Sector': user.sector
+                };
+                this.doc.addRow(2, newRow, function(err, result) {
+                  if (err) {
+                    return reject(err);
+                  }
+                  logger.info('Added row in spreedsheet');
+                  resolve(result);
+                });
+            }.bind(this));
+        } catch (err) {
+            logger.error(err);
+        }
+    }
+
+    * updateCells(row, user) {
+        try {
+            logger.info('Getting user....');
+            return new Promise(function(resolve, reject) {
+                this.doc.getRows(2, {
+                    'offset': row.row - 1,
+                    'limit': 1
+                }, function(err, row) {
+                  if (err) {
+                    return reject(err);
+                  }
+                  logger.info('Found user....');
+                  row[0].first = user.fullName;
+                  row[0].addresslocation = user.city + ', ' + user.state + ', ' + user.country;
+                  row[0].organizationsector = user.sector;
+                  row[0].positionprimaryresponsibilities = user.primaryResponsibilities;
+                  row[0].source = 'My GFW';
+                  row[0].otherhowdoyouuseorplantousegfw = user.howDoYouUse;
+                  row[0].agreedtotest = user.signUpForTesting === true ? 'yes' : 'no';
+                  row[0].save(function(){
+                      logger.info('User updated');
+                      resolve(row);
+                  });
+                });
+            }.bind(this));
+        } catch (err) {
+           logger.debug(err);
+        }
+    }
+
+    * checkRows(){
+        try {
+            logger.debug('Checking rows....');
+            return new Promise(function(resolve, reject) {
+                this.doc.getCells(2, {
+                    'min-col': 5,
+                    'max-col': 5
+                }, function(err, result) {
+                  if (err) {
+                    return reject(err);
+                  }
+                  resolve(result);
+                });
+            }.bind(this));
+        } catch (err) {
+           logger.debug(err);
+        }
+    }
+
+    getDate(){
+        var today = new Date();
+        var dd = today.getDate();
+        var mm = today.getMonth()+1; //January is 0!
+
+        var yyyy = today.getFullYear();
+        if( dd < 10 ){
+            dd = '0' + dd;
+        }
+        if( mm < 10 ){
+            mm = '0' + mm;
+        }
+        today = mm + '/' + dd + '/' + yyyy;
+        return today;
+    }
+
+}
+
+module.exports = new GoogleSheetsService();

--- a/app/src/services/googleSheetsService.js
+++ b/app/src/services/googleSheetsService.js
@@ -48,7 +48,7 @@ class GoogleSheetsService {
                     'Position Primary Responsibilities': user.primaryResponsibilities,
                     'Organization Sector': user.sector
                 };
-                this.doc.addRow(2, newRow, function(err, result) {
+                this.doc.addRow(this.creds.target_sheet_index, newRow, function(err, result) {
                   if (err) {
                     return reject(err);
                   }
@@ -65,7 +65,7 @@ class GoogleSheetsService {
         try {
             logger.info('Getting user....');
             return new Promise(function(resolve, reject) {
-                this.doc.getRows(2, {
+                this.doc.getRows(this.creds.target_sheet_index, {
                     'offset': row.row - 1,
                     'limit': 1
                 }, function(err, row) {
@@ -95,7 +95,7 @@ class GoogleSheetsService {
         try {
             logger.debug('Checking rows....');
             return new Promise(function(resolve, reject) {
-                this.doc.getCells(2, {
+                this.doc.getCells(this.creds.target_sheet_index, {
                     'min-col': 5,
                     'max-col': 5
                 }, function(err, result) {

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -16,6 +16,7 @@
     "googleSheets":{
         "private_key" : "GOOGLE_PRIVATE_KEY",
         "client_email": "GOOGLE_PROJECT_EMAIL",
-        "target_sheet_id": "TARGET_SHEET_ID"
+        "target_sheet_id": "TARGET_SHEET_ID",
+        "target_sheet_index": "TARGET_SHEET_INDEX"
     }
 }

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,5 +12,10 @@
     },
     "migrate":{
         "uri": "MIGRATE_URI"
+    },
+    "googleSheets":{
+        "private_key" : "GOOGLE_PRIVATE_KEY",
+        "client_email": "GOOGLE_PROJECT_EMAIL",
+        "target_sheet_id": "TARGET_SHEET_ID"
     }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -21,5 +21,10 @@
     },
     "migrate":{
         "uri": ""
+    },
+    "googleSheets":{
+        "private_key" : "",
+        "client_email": "",
+        "target_sheet_id": ""
     }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -25,6 +25,7 @@
     "googleSheets":{
         "private_key" : "",
         "client_email": "",
-        "target_sheet_id": ""
+        "target_sheet_id": "",
+        "target_sheet_index": null
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "co-request": "1.0.0",
     "config": "1.19.0",
     "geojsonhint": "1.2.0",
+    "google-spreadsheet": "^2.0.3",
     "grunt-run": "^0.6.0",
     "jsonapi-serializer": "2.1.1",
     "koa": "1.1.2",
@@ -43,9 +44,9 @@
     "koa-qs": "^2.0.0",
     "koa-router": "5.4.0",
     "koa-validate": "0.2.11",
-    "vizz.microservice-client": "1.5.1",
     "mongoose": "4.4.6",
-    "newrelic": "1.27.1"
+    "newrelic": "1.27.1",
+    "vizz.microservice-client": "1.5.1"
   },
   "devDependencies": {
     "co-mocha": "1.1.2",


### PR DESCRIPTION
New service to sync user data from My GFW to the beta tester google sheet:
- Capture data from sign up and update profile forms in My GFW
- Map this data to corresponding fields in GFW beta test spread sheet
- Send fields to google sheets
- Allow for opt in/opt out from profile update

Current workflow:
- When a user creates a profile with My GFW and opts into beta testing, the form info is appended to the google sheet.
- If a user updates their profile, either remaining as a beta tester or opting out, all form data is updated and the user agreed_to_test field is set to reflect opt in choice.

Notes: An index for the sheets is set in the service script. It is currently set to 2. Please adjust for production (non zero indexing).