### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -28,7 +28,7 @@ services:
     container_name: gfw-user-mongo-develop
     command: --smallfiles
     ports:
-      - "27017"
+      - "27019:27017"
     volumes:
       - $HOME/docker/data/dataset:/data/db
     restart: always


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Allow external connections to mongodb